### PR TITLE
update(docs): next-forms fix unhandled run time error

### DIFF
--- a/examples/next-forms/app/actions.ts
+++ b/examples/next-forms/app/actions.ts
@@ -13,9 +13,15 @@ export async function createTodo(prevState: any, formData: FormData) {
   const schema = z.object({
     todo: z.string().min(1),
   })
-  const data = schema.parse({
+  const parse = schema.safeParse({
     todo: formData.get('todo'),
   })
+
+  if (!parse.success) {
+    return { message: 'Failed to create todo' }
+  }
+
+  const data = parse.data;
 
   try {
     await sql`

--- a/examples/next-forms/app/actions.ts
+++ b/examples/next-forms/app/actions.ts
@@ -21,7 +21,7 @@ export async function createTodo(prevState: any, formData: FormData) {
     return { message: 'Failed to create todo' }
   }
 
-  const data = parse.data;
+  const data = parse.data
 
   try {
     await sql`


### PR DESCRIPTION
### What?
The `zod.parse()` in the example will cause an unexpected run time error. Proposed solve is to use `zod.safeParse()` so there won't be an unhandled error exception. `Question`: use `try/catch` or `safeParse`?

### Why?
Example for next-forms will have an unexpected run time error with the current implementation. Changed it so it will be handled through safeParse. So when users are following this portion of the docs they will not encounter an unexpected run time error if they enter an empty string.

### How?
`parse()` throws an error, and because the server action does not have a top level try/catch to handle the exception, it eventually bubbles up to an `Unhandled Runtime Error`
